### PR TITLE
feat: make feed item background white and fix heatmap colors

### DIFF
--- a/components/ui/contribution-heatmap.tsx
+++ b/components/ui/contribution-heatmap.tsx
@@ -6,12 +6,20 @@ const ContributionHeatmap = () => {
     count: Math.floor(Math.random() * 5),
   }))
 
+  const levelClasses = [
+    "bg-cream-white-surface",
+    "bg-basil-green/20",
+    "bg-basil-green/40",
+    "bg-basil-green/60",
+    "bg-basil-green",
+  ]
+
   return (
     <div className="flex flex-wrap gap-1">
       {data.map((day, i) => (
         <div
           key={i}
-          className={`h-4 w-4 rounded-sm ${day.count > 0 ? `bg-basil-green/${day.count * 20}` : "bg-gray-200"}`}
+          className={`h-4 w-4 rounded-sm ${levelClasses[day.count]}`}
           title={`${day.date.toDateString()} - ${day.count} harvested`}
         ></div>
       ))}

--- a/components/ui/feed-item.tsx
+++ b/components/ui/feed-item.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 
 const FeedItem = () => {
   return (
-    <div className="flex items-center gap-4 rounded-lg bg-cream-white-surface p-4">
+    <div className="flex items-center gap-4 rounded-lg bg-white p-4">
       <div className="h-12 w-12 rounded-full bg-gray-300"></div>
       <div>
         <p className="font-semibold">@박씨, 토마토 2개 수확 🍅🍅</p>


### PR DESCRIPTION
## Summary
- make feed item background white
- apply design system colors to contribution heatmap

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894328762a483289a5cf28a557d86d5