### PR TITLE
feat: add SQL schema

### DIFF
--- a/docs/database.sql
+++ b/docs/database.sql
@@ -1,0 +1,109 @@
+DROP TABLE IF EXISTS praises_supports CASCADE;
+DROP TABLE IF EXISTS proofs CASCADE;
+DROP TABLE IF EXISTS pomodoros CASCADE;
+DROP TABLE IF EXISTS tasks CASCADE;
+DROP TABLE IF EXISTS user_teams CASCADE;
+DROP TABLE IF EXISTS farms CASCADE;
+DROP TABLE IF EXISTS teams CASCADE;
+DROP TABLE IF EXISTS users CASCADE;
+
+DROP TYPE IF EXISTS task_status;
+DROP TYPE IF EXISTS pomodoro_status;
+DROP TYPE IF EXISTS proof_type;
+
+CREATE TYPE task_status AS ENUM ('todo', 'in_progress', 'done');
+CREATE TYPE pomodoro_status AS ENUM ('active', 'completed', 'cancelled');
+CREATE TYPE proof_type AS ENUM ('text', 'image', 'link');
+
+CREATE TABLE users (
+    id UUID PRIMARY KEY,
+    nickname TEXT UNIQUE NOT NULL,
+    email TEXT UNIQUE NOT NULL,
+    google_id TEXT UNIQUE,
+    pomodoro_focus_duration INTEGER NOT NULL,
+    pomodoro_break_duration INTEGER NOT NULL,
+    pomodoro_long_break_duration INTEGER NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE teams (
+    id UUID PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE farms (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_farms_user_id ON farms(user_id);
+
+CREATE TABLE user_teams (
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    role TEXT,
+    PRIMARY KEY (user_id, team_id)
+);
+CREATE INDEX idx_user_teams_user_id ON user_teams(user_id);
+CREATE INDEX idx_user_teams_team_id ON user_teams(team_id);
+
+CREATE TABLE tasks (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    farm_id UUID REFERENCES farms(id) ON DELETE SET NULL,
+    title TEXT NOT NULL,
+    description TEXT,
+    estimated_pomodoros INTEGER,
+    due_date TIMESTAMPTZ,
+    task_status task_status NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_tasks_user_id ON tasks(user_id);
+CREATE INDEX idx_tasks_farm_id ON tasks(farm_id);
+
+CREATE TABLE pomodoros (
+    id UUID PRIMARY KEY,
+    task_id UUID NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    pomodoro_status pomodoro_status NOT NULL,
+    start_time TIMESTAMPTZ NOT NULL,
+    end_time TIMESTAMPTZ,
+    duration_minutes INTEGER,
+    is_long_break BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_pomodoros_task_id ON pomodoros(task_id);
+CREATE INDEX idx_pomodoros_user_id ON pomodoros(user_id);
+
+CREATE TABLE proofs (
+    id UUID PRIMARY KEY,
+    task_id UUID NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    proof_type proof_type NOT NULL,
+    content TEXT NOT NULL,
+    description TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_proofs_task_id ON proofs(task_id);
+CREATE INDEX idx_proofs_user_id ON proofs(user_id);
+
+CREATE TABLE praises_supports (
+    id UUID PRIMARY KEY,
+    task_id UUID NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    from_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    type TEXT NOT NULL,
+    content TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_praises_supports_task_id ON praises_supports(task_id);
+CREATE INDEX idx_praises_supports_from_user_id ON praises_supports(from_user_id);


### PR DESCRIPTION
## Summary
- add SQL script translating ER diagram to tables, types, and indexes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `psql -f docs/database.sql` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899f567d35c8328a8b5ab2dee5e4272