### PR TITLE
feat: add database initialization page

### DIFF
--- a/app/initialize/page.tsx
+++ b/app/initialize/page.tsx
@@ -5,16 +5,17 @@ import fs from 'fs/promises';
 import path from 'path';
 
 async function runSql(query: string) {
-  const url = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/pg`;
+  const url = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1`;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
   const res = await fetch(url, {
     method: 'POST',
     headers: {
       apikey: key,
       Authorization: `Bearer ${key}`,
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/vnd.pgrst.sql',
+      Accept: 'application/json',
     },
-    body: JSON.stringify({ query }),
+    body: query,
   });
   const data = await res.json().catch(() => ({}));
   if (!res.ok || data.error) {

--- a/app/initialize/page.tsx
+++ b/app/initialize/page.tsx
@@ -7,20 +7,20 @@ import path from 'path';
 
 async function ensureSchema() {
   try {
-    const { data, error } = await supabaseAdmin
-      .from('information_schema.tables')
-      .select('table_name')
-      .eq('table_schema', 'public')
-      .limit(1);
-
+    const query =
+      "select table_name from information_schema.tables where table_schema = 'public' limit 1";
+    const { data, error } = await supabaseAdmin.rpc('exec_sql', { query });
     if (error) {
       return { success: false, message: error.message };
     }
 
-    if (data.length === 0) {
+    const tables = (data as { table_name: string }[]) ?? [];
+    if (tables.length === 0) {
       const sqlPath = path.join(process.cwd(), 'docs', 'database.sql');
       const sql = await fs.readFile(sqlPath, 'utf8');
-      const { error: execError } = await supabaseAdmin.rpc('exec_sql', { query: sql });
+      const { error: execError } = await supabaseAdmin.rpc('exec_sql', {
+        query: sql,
+      });
       if (execError) {
         return { success: false, message: execError.message };
       }

--- a/app/initialize/page.tsx
+++ b/app/initialize/page.tsx
@@ -5,21 +5,22 @@ import fs from 'fs/promises';
 import path from 'path';
 
 async function runSql(query: string) {
-  const url = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/rest/v1`;
+  const url = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/pg`;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
   const res = await fetch(url, {
     method: 'POST',
     headers: {
       apikey: key,
       Authorization: `Bearer ${key}`,
-      'Content-Type': 'application/vnd.pgrst.sql',
+      'Content-Type': 'application/json',
       Accept: 'application/json',
     },
-    body: query,
+    body: JSON.stringify({ query }),
   });
-  const data = await res.json().catch(() => ({}));
-  if (!res.ok || data.error) {
-    return { data: null, error: data.error || res.statusText };
+  const json = await res.json().catch(() => ({}));
+  const data = json.result ?? json;
+  if (!res.ok || json.error) {
+    return { data: null, error: json.error || res.statusText };
   }
   return { data, error: null };
 }

--- a/app/initialize/page.tsx
+++ b/app/initialize/page.tsx
@@ -49,16 +49,21 @@ async function resetDatabase() {
   }
 }
 
-export default async function InitializePage({ searchParams }: { searchParams?: { reset?: string } }) {
+type InitializePageProps = {
+  searchParams?: Promise<{ reset?: string }>;
+};
+
+export default async function InitializePage({ searchParams }: InitializePageProps) {
+  const params = (await searchParams) ?? {};
   const result = await ensureSchema();
 
   return (
     <div className="space-y-4 p-4">
       <p className={result.success ? 'text-green-600' : 'text-red-600'}>{result.message}</p>
-      {searchParams?.reset === 'success' && (
+      {params.reset === 'success' && (
         <p className="text-green-600">Database reset successfully.</p>
       )}
-      {searchParams?.reset === 'error' && (
+      {params.reset === 'error' && (
         <p className="text-red-600">Failed to reset database.</p>
       )}
       <form action={resetDatabase}>

--- a/app/initialize/page.tsx
+++ b/app/initialize/page.tsx
@@ -1,0 +1,72 @@
+import { supabaseAdmin } from '@/lib/supabase-admin';
+import { Button } from '@/components/ui/button';
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import fs from 'fs/promises';
+import path from 'path';
+
+async function ensureSchema() {
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('information_schema.tables')
+      .select('table_name')
+      .eq('table_schema', 'public')
+      .limit(1);
+
+    if (error) {
+      return { success: false, message: error.message };
+    }
+
+    if (data.length === 0) {
+      const sqlPath = path.join(process.cwd(), 'docs', 'database.sql');
+      const sql = await fs.readFile(sqlPath, 'utf8');
+      const { error: execError } = await supabaseAdmin.rpc('exec_sql', { query: sql });
+      if (execError) {
+        return { success: false, message: execError.message };
+      }
+      return { success: true, message: 'Database initialized successfully.' };
+    }
+
+    return { success: true, message: 'Database already initialized.' };
+  } catch (err) {
+    return { success: false, message: (err as Error).message };
+  }
+}
+
+async function resetDatabase() {
+  'use server';
+  try {
+    const sqlPath = path.join(process.cwd(), 'docs', 'database.sql');
+    const sql = await fs.readFile(sqlPath, 'utf8');
+    const { error } = await supabaseAdmin.rpc('exec_sql', { query: sql });
+    if (error) {
+      redirect('/initialize?reset=error');
+    }
+    revalidatePath('/initialize');
+    redirect('/initialize?reset=success');
+  } catch {
+    redirect('/initialize?reset=error');
+  }
+}
+
+export default async function InitializePage({ searchParams }: { searchParams?: { reset?: string } }) {
+  const result = await ensureSchema();
+
+  return (
+    <div className="space-y-4 p-4">
+      <p className={result.success ? 'text-green-600' : 'text-red-600'}>{result.message}</p>
+      {searchParams?.reset === 'success' && (
+        <p className="text-green-600">Database reset successfully.</p>
+      )}
+      {searchParams?.reset === 'error' && (
+        <p className="text-red-600">Failed to reset database.</p>
+      )}
+      <form action={resetDatabase}>
+        <Button type="submit" variant="destructive">
+          Reset Database
+        </Button>
+      </form>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `/initialize` server page that checks for schema and runs `docs/database.sql`
- allow database reset via server action button

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899f8b7e8b083289f1d7488ddadee85