### PR TITLE
feat: add initialize page for supabase

### DIFF
--- a/app/initialize/page.tsx
+++ b/app/initialize/page.tsx
@@ -1,0 +1,103 @@
+import { createClient } from '@supabase/supabase-js';
+
+export default async function Initialize() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+  const supabase = createClient(supabaseUrl, serviceKey);
+
+  const sql = `
+    create type if not exists task_status as enum ('pending','in_progress','completed');
+    create type if not exists pomodoro_status as enum ('focus','break','long_break');
+    create type if not exists proof_type as enum ('image','text','link');
+
+    create table if not exists users (
+      id uuid primary key,
+      nickname text unique,
+      email text unique,
+      google_id text unique,
+      pomodoro_focus_duration integer,
+      pomodoro_break_duration integer,
+      pomodoro_long_break_duration integer,
+      created_at timestamp,
+      updated_at timestamp
+    );
+
+    create table if not exists farms (
+      id uuid primary key,
+      user_id uuid references users(id),
+      name text,
+      start_date date,
+      end_date date,
+      created_at timestamp,
+      updated_at timestamp
+    );
+
+    create table if not exists teams (
+      id uuid primary key,
+      name text unique,
+      created_at timestamp,
+      updated_at timestamp
+    );
+
+    create table if not exists user_teams (
+      user_id uuid references users(id),
+      team_id uuid references teams(id),
+      role text,
+      primary key (user_id, team_id)
+    );
+
+    create table if not exists tasks (
+      id uuid primary key,
+      user_id uuid references users(id),
+      farm_id uuid references farms(id),
+      title text,
+      description text,
+      estimated_pomodoros integer,
+      due_date timestamp,
+      task_status task_status,
+      created_at timestamp,
+      updated_at timestamp
+    );
+
+    create table if not exists pomodoros (
+      id uuid primary key,
+      task_id uuid references tasks(id),
+      user_id uuid references users(id),
+      pomodoro_status pomodoro_status,
+      start_time timestamp,
+      end_time timestamp,
+      duration_minutes integer,
+      is_long_break boolean,
+      created_at timestamp,
+      updated_at timestamp
+    );
+
+    create table if not exists proofs (
+      id uuid primary key,
+      task_id uuid references tasks(id),
+      user_id uuid references users(id),
+      proof_type proof_type,
+      content text,
+      description text,
+      created_at timestamp,
+      updated_at timestamp
+    );
+
+    create table if not exists praises_supports (
+      id uuid primary key,
+      task_id uuid references tasks(id),
+      from_user_id uuid references users(id),
+      type text,
+      content text,
+      created_at timestamp
+    );
+  `;
+
+  await supabase.rpc('pg_exec', { query: sql });
+
+  return (
+    <main className="container mx-auto p-4">
+      <h1 className="text-headline font-bold">Database initialized</h1>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,108 +1,17 @@
+import HomePage from '@/components/home-page';
+import { createClient } from '@supabase/supabase-js';
+import { redirect } from 'next/navigation';
 
-'use client';
+export default async function Page() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+  const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
-import { Button } from "@/components/ui/button";
-import { ContributionHeatmap } from "@/components/ui/contribution-heatmap";
-import { FeedItem } from "@/components/ui/feed-item";
-import { PomodoroTimer } from "@/components/ui/pomodoro-timer";
-import Link from "next/link";
-import { useEffect, useState } from 'react';
-import { supabase } from '@/lib/supabase';
-import { User } from '@supabase/supabase-js';
+  const { error } = await supabase.from('users').select('id').limit(1);
 
-import { ClientToggleSwitch } from "@/components/client-toggle-switch";
-import { TaskCard } from "@/components/ui/task-card";
+  if (error && error.code === '42P01') {
+    redirect('/initialize');
+  }
 
-export default function Home() {
-  const [user, setUser] = useState<User | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const getSession = async () => {
-      const { data: { session } } = await supabase.auth.getSession();
-      setUser(session?.user ?? null);
-      setLoading(false);
-    };
-
-    getSession();
-
-    const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {
-      setUser(session?.user ?? null);
-    });
-
-    return () => {
-      authListener.subscription.unsubscribe();
-    };
-  }, []);
-
-  const handleSignOut = async () => {
-    await supabase.auth.signOut();
-  };
-
-  return (
-    <main className="container mx-auto p-4">
-      <header className="flex justify-between items-center mb-8">
-        <h1 className="text-headline font-bold">Toma</h1>
-        <div>
-          {loading ? (
-            <p>Loading...</p>
-          ) : user ? (
-            <div className="flex items-center space-x-4">
-              <p>{user.email}</p>
-              <Button variant="outline" onClick={handleSignOut}>Sign Out</Button>
-            </div>
-          ) : (
-            <Link href="/auth">
-              <Button variant="outline">Sign In</Button>
-            </Link>
-          )}
-        </div>
-      </header>
-
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-        <div className="md:col-span-2">
-          <h2 className="text-subheadline font-semibold mb-4">My Field</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <TaskCard title="Plant tomatoes" dueDate="Aug 25" status="growing" />
-            <TaskCard title="Put tomatoes" dueDate="Aug 24" status="waiting" />
-            <TaskCard title="Due" status="harvested" harvestedCount={3} />
-          </div>
-
-          <div className="mt-8">
-            <h2 className="text-subheadline font-semibold mb-4">Feed</h2>
-            <div className="space-y-4">
-              <FeedItem />
-              <FeedItem />
-            </div>
-          </div>
-        </div>
-
-        <div className="space-y-8">
-          <div>
-            <h2 className="text-subheadline font-semibold mb-4">Pomodoro</h2>
-            <PomodoroTimer />
-          </div>
-
-          <div>
-            <h2 className="text-subheadline font-semibold mb-4">Buttons</h2>
-            <div className="flex flex-col space-y-2">
-              <Button>Primary Button</Button>
-              <Button variant="outline">Secondary Button</Button>
-              <Button variant="cta">+</Button>
-            </div>
-          </div>
-
-          <div>
-            <h2 className="text-subheadline font-semibold mb-4">Toggle Switch</h2>
-            <ClientToggleSwitch />
-          </div>
-
-          <div>
-            <h2 className="text-subheadline font-semibold mb-4">Contribution</h2>
-            <ContributionHeatmap />
-          </div>
-        </div>
-      </div>
-    </main>
-  );
+  return <HomePage />;
 }

--- a/components/home-page.tsx
+++ b/components/home-page.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { Button } from "@/components/ui/button";
+import { ContributionHeatmap } from "@/components/ui/contribution-heatmap";
+import { FeedItem } from "@/components/ui/feed-item";
+import { PomodoroTimer } from "@/components/ui/pomodoro-timer";
+import Link from "next/link";
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { User } from '@supabase/supabase-js';
+
+import { ClientToggleSwitch } from "@/components/client-toggle-switch";
+import { TaskCard } from "@/components/ui/task-card";
+
+export default function HomePage() {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const getSession = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      setUser(session?.user ?? null);
+      setLoading(false);
+    };
+
+    getSession();
+
+    const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => {
+      authListener.subscription.unsubscribe();
+    };
+  }, []);
+
+  const handleSignOut = async () => {
+    await supabase.auth.signOut();
+  };
+
+  return (
+    <main className="container mx-auto p-4">
+      <header className="flex justify-between items-center mb-8">
+        <h1 className="text-headline font-bold">Toma</h1>
+        <div>
+          {loading ? (
+            <p>Loading...</p>
+          ) : user ? (
+            <div className="flex items-center space-x-4">
+              <p>{user.email}</p>
+              <Button variant="outline" onClick={handleSignOut}>Sign Out</Button>
+            </div>
+          ) : (
+            <Link href="/auth">
+              <Button variant="outline">Sign In</Button>
+            </Link>
+          )}
+        </div>
+      </header>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div className="md:col-span-2">
+          <h2 className="text-subheadline font-semibold mb-4">My Field</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <TaskCard title="Plant tomatoes" dueDate="Aug 25" status="growing" />
+            <TaskCard title="Put tomatoes" dueDate="Aug 24" status="waiting" />
+            <TaskCard title="Due" status="harvested" harvestedCount={3} />
+          </div>
+
+          <div className="mt-8">
+            <h2 className="text-subheadline font-semibold mb-4">Feed</h2>
+            <div className="space-y-4">
+              <FeedItem />
+              <FeedItem />
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-8">
+          <div>
+            <h2 className="text-subheadline font-semibold mb-4">Pomodoro</h2>
+            <PomodoroTimer />
+          </div>
+
+          <div>
+            <h2 className="text-subheadline font-semibold mb-4">Buttons</h2>
+            <div className="flex flex-col space-y-2">
+              <Button>Primary Button</Button>
+              <Button variant="outline">Secondary Button</Button>
+              <Button variant="cta">+</Button>
+            </div>
+          </div>
+
+          <div>
+            <h2 className="text-subheadline font-semibold mb-4">Toggle Switch</h2>
+            <ClientToggleSwitch />
+          </div>
+
+          <div>
+            <h2 className="text-subheadline font-semibold mb-4">Contribution</h2>
+            <ContributionHeatmap />
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,7 +1,6 @@
-
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://kmdtswcayohamrxbgptf.supabase.co';
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImttZHRzd2NheW9oYW1yeGJncHRmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQzNzQ5OTAsImV4cCI6MjA2OTk1MDk5MH0.Gtkq8_bpDOiUeXDQPdkrxtLR2FNtrZlmoTka1x_9KaA';
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- use env vars for supabase client
- add initialize page that sets up schema on load
- redirect to initialize when tables are missing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ad2c1ef208328a4612b2c4c4b7ba7