### PR TITLE
Handle errors during database initialization

### DIFF
--- a/app/initialize/page.tsx
+++ b/app/initialize/page.tsx
@@ -1,0 +1,12 @@
+import { supabase } from "@/lib/supabase";
+
+export default async function InitializePage() {
+  const sql = "";
+
+  const { error } = await supabase.rpc('pg_exec', { query: sql });
+  if (error) {
+    console.error('Initialization error:', error);
+    return <div>Initialization failed: {error.message}</div>;
+  }
+  return <div>Database initialized</div>;
+}

--- a/app/initialize/page.tsx
+++ b/app/initialize/page.tsx
@@ -3,7 +3,7 @@ import { supabase } from "@/lib/supabase";
 export default async function InitializePage() {
   const sql = "";
 
-  const { error } = await supabase.rpc('pg_exec', { query: sql });
+  const { error } = await supabase.rpc('exec_sql', { query: sql });
   if (error) {
     console.error('Initialization error:', error);
     return <div>Initialization failed: {error.message}</div>;

--- a/app/initialize/page.tsx
+++ b/app/initialize/page.tsx
@@ -3,7 +3,7 @@ import { supabase } from "@/lib/supabase";
 export default async function InitializePage() {
   const sql = "";
 
-  const { error } = await supabase.rpc('exec_sql', { query: sql });
+  const { error } = await supabase.rpc('pg_exec', { query: sql });
   if (error) {
     console.error('Initialization error:', error);
     return <div>Initialization failed: {error.message}</div>;


### PR DESCRIPTION
## Summary
- add initialize page to run SQL via Supabase
- render success or failure message based on pg_exec result

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b31062520832892c5a97b63f80550