### PR TITLE
feat: add pg_exec SQL function

### DIFF
--- a/docs/pg_exec.md
+++ b/docs/pg_exec.md
@@ -1,0 +1,26 @@
+# `pg_exec` helper function
+
+This SQL function allows executing arbitrary SQL statements via the Supabase RPC interface.
+
+```sql
+create or replace function public.pg_exec(query text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  execute query;
+end;
+$$;
+
+grant execute on function public.pg_exec(text) to authenticated, service_role, anon;
+```
+
+Call it from `supabase-js`:
+
+```ts
+await supabase.rpc('pg_exec', { query: 'select 1;' });
+```
+
+> ⚠️ Executing arbitrary SQL is dangerous. Restrict access to trusted roles only.

--- a/supabase/migrations/20250525000000_pg_exec.sql
+++ b/supabase/migrations/20250525000000_pg_exec.sql
@@ -1,0 +1,12 @@
+create or replace function public.pg_exec(query text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  execute query;
+end;
+$$;
+
+grant execute on function public.pg_exec(text) to authenticated, service_role, anon;


### PR DESCRIPTION
## Summary
- add `pg_exec` SQL function to run arbitrary queries via Supabase RPC
- document how to create and call the `pg_exec` helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b3ee570a883288e7e3454b273adc9