### PR TITLE
feat: add database initializer page

### DIFF
--- a/app/initialize/page.tsx
+++ b/app/initialize/page.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import { setupDatabase } from '@/lib/setupDatabase';
+
+export const metadata = {
+  title: 'Initialize Database',
+};
+
+export default async function InitializePage() {
+  const result = await setupDatabase();
+
+  return (
+    <div className="p-4 space-y-4">
+      {result.success ? (
+        <p>Database initialized successfully.</p>
+      ) : (
+        <p>Failed to initialize database: {result.error}</p>
+      )}
+      <Link href="/" className="text-blue-500 underline">
+        Back to Home
+      </Link>
+    </div>
+  );
+}

--- a/lib/setupDatabase.ts
+++ b/lib/setupDatabase.ts
@@ -1,0 +1,104 @@
+import 'server-only';
+import { supabaseAdmin } from './supabaseAdmin';
+
+/**
+ * Initializes database tables defined in docs/database.md.
+ * Uses the service role client to run CREATE TABLE statements.
+ */
+export async function setupDatabase() {
+  const createTablesSql = `
+    create table if not exists users (
+      id uuid primary key,
+      nickname text unique,
+      email text unique,
+      google_id text unique,
+      pomodoro_focus_duration integer,
+      pomodoro_break_duration integer,
+      pomodoro_long_break_duration integer,
+      created_at timestamp default now(),
+      updated_at timestamp default now()
+    );
+
+    create table if not exists farms (
+      id uuid primary key,
+      user_id uuid references users(id),
+      name text,
+      start_date date,
+      end_date date,
+      created_at timestamp default now(),
+      updated_at timestamp default now()
+    );
+
+    create table if not exists teams (
+      id uuid primary key,
+      name text unique,
+      created_at timestamp default now(),
+      updated_at timestamp default now()
+    );
+
+    create table if not exists user_teams (
+      user_id uuid references users(id),
+      team_id uuid references teams(id),
+      role text,
+      primary key (user_id, team_id)
+    );
+
+    create table if not exists tasks (
+      id uuid primary key,
+      user_id uuid references users(id),
+      farm_id uuid references farms(id),
+      title text,
+      description text,
+      estimated_pomodoros integer,
+      due_date timestamp,
+      task_status text,
+      created_at timestamp default now(),
+      updated_at timestamp default now()
+    );
+
+    create table if not exists pomodoros (
+      id uuid primary key,
+      task_id uuid references tasks(id),
+      user_id uuid references users(id),
+      pomodoro_status text,
+      start_time timestamp,
+      end_time timestamp,
+      duration_minutes integer,
+      is_long_break boolean,
+      created_at timestamp default now(),
+      updated_at timestamp default now()
+    );
+
+    create table if not exists proofs (
+      id uuid primary key,
+      task_id uuid references tasks(id),
+      user_id uuid references users(id),
+      proof_type text,
+      content text,
+      description text,
+      created_at timestamp default now(),
+      updated_at timestamp default now()
+    );
+
+    create table if not exists praises_supports (
+      id uuid primary key,
+      task_id uuid references tasks(id),
+      from_user_id uuid references users(id),
+      type text,
+      content text,
+      created_at timestamp default now()
+    );
+  `;
+
+  try {
+    // Attempt to run SQL using the service-role client. Depending on your Supabase setup,
+    // you may need to create a Postgres function that executes raw SQL.
+    const { error } = await supabaseAdmin.rpc('exec_sql', { sql: createTablesSql });
+    if (error) {
+      return { success: false, error: error.message };
+    }
+    return { success: true };
+  } catch (err: unknown) {
+    return { success: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}


### PR DESCRIPTION
## Summary
- add `/initialize` route to create missing tables
- add helper to initialize database using Supabase service role

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b4567f4608328a2601ec7eb3e4ff9