### PR TITLE
Add Neon database connection and example API route

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL="postgres://user:password@host/database"

--- a/app/api/dbtest/route.ts
+++ b/app/api/dbtest/route.ts
@@ -1,0 +1,6 @@
+import { db } from '@/lib/db';
+
+export async function GET() {
+  const result = await db.query('SELECT 1');
+  return Response.json(result.rows);
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,6 @@
+import { Pool } from '@neondatabase/serverless';
+
+// Create a connection pool to the Neon database
+export const db = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "autoprefixer": "^10.4.21",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "@neondatabase/serverless": "^0.10.4",
+    "pg": "^8.11.3",
     "next": "15.4.5",
     "react": "19.1.0",
     "react-dom": "19.1.0",


### PR DESCRIPTION
## Summary
- add Neon serverless pool and exportable `db` connection
- set up sample API route querying the database
- document database connection URL in env

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Module not found: Can't resolve '@neondatabase/serverless')*

------
https://chatgpt.com/codex/tasks/task_e_689c8fdb062483288c978c29afa6f464