### PR TITLE
feat: add basic next-auth setup

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import SessionProvider from "@/components/session-provider";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -16,7 +17,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <SessionProvider>{children}</SessionProvider>
+      </body>
     </html>
   );
 }

--- a/components/session-provider.tsx
+++ b/components/session-provider.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { SessionProvider } from 'next-auth/react';
+
+export default function AuthSessionProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,12 @@
+import type { NextAuthOptions } from 'next-auth';
+import GitHub from 'next-auth/providers/github';
+
+export const authOptions: NextAuthOptions = {
+  secret: process.env.AUTH_SECRET,
+  providers: [
+    GitHub({
+      clientId: process.env.GITHUB_ID ?? '',
+      clientSecret: process.env.GITHUB_SECRET ?? '',
+    }),
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clsx": "^2.1.1",
     "@neondatabase/serverless": "^0.10.4",
     "pg": "^8.11.3",
-    "@auth/core": "^1.0.0",
+    "@auth/core": "^0.16.0",
     "next-auth": "^5.0.0",
     "next": "15.4.5",
     "react": "19.1.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "clsx": "^2.1.1",
     "@neondatabase/serverless": "^0.10.4",
     "pg": "^8.11.3",
+    "@auth/core": "^1.0.0",
+    "next-auth": "^5.0.0",
     "next": "15.4.5",
     "react": "19.1.0",
     "react-dom": "19.1.0",


### PR DESCRIPTION
## Summary
- add NextAuth dependencies
- implement GitHub auth route and options
- wrap app with SessionProvider

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter` and missing `next-auth` modules)*

------
https://chatgpt.com/codex/tasks/task_e_689c93b6f00c8328b07f0a83b18851ef